### PR TITLE
feat: Use `node-fetch` for maximized compatibility

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,9 +1,31 @@
-const { execSync } = require('child_process');
+import { execSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+import fs from 'fs';
 
-// Compile TypeScript
-execSync('tsc');
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
-// Copy non-TS files to dist folder
-execSync('cp -R lib/* dist/');
+try {
+    // Compile TypeScript
+    execSync('tsc', { stdio: 'inherit' });
 
-console.log('Build complete.');
+    // Copy non-TS files to dist folder
+    const sourceDir = 'lib';
+    const targetDir = 'dist';
+
+    if (!fs.existsSync(targetDir)) {
+        fs.mkdirSync(targetDir);
+    }
+
+    fs.readdirSync(sourceDir).forEach(file => {
+        if (!file.endsWith('.ts')) {
+            fs.copyFileSync(`${sourceDir}/${file}`, `${targetDir}/${file}`);
+        }
+    });
+
+    console.log('Build complete.');
+} catch (error) {
+    console.error('Build failed:', error);
+    process.exit(1);
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,16 @@
-module.exports = {
-    preset: 'ts-jest',
-    testEnvironment: 'node',
-    testMatch: ['**/tests/**/*.test.ts'],
-  };
-  
+export default {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        useESM: true,
+      },
+    ],
+  },
+};

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,7 +3,8 @@ import {
   IngredientsCheckResponse,
   PetaCrueltyFreeResponse,
   ErrorResponse,
-} from "./interfaces";
+} from "./interfaces.js";
+import fetch from "node-fetch";
 
 const PRODUCTION_API_BASE_URL = "https://api.veganify.app/v0";
 const STAGING_API_BASE_URL = "https://staging.api.veganify.app/v0";
@@ -17,57 +18,39 @@ const Veganify = {
     barcode: string,
     staging?: boolean
   ): Promise<ProductResponse | ErrorResponse> => {
-    try {
-      const API_BASE_URL = getApiBaseUrl(staging);
-      const response = await fetch(`${API_BASE_URL}/product/${barcode}`, {
-        method: "POST",
-      });
-
-      if (!response.ok) {
-        throw { response: { status: response.status } };
-      }
-
-      return await response.json();
-    } catch (error) {
-      throw error;
+    const API_BASE_URL = getApiBaseUrl(staging);
+    const response = await fetch(`${API_BASE_URL}/product/${barcode}`, {
+      method: "POST",
+    });
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
     }
+    return (await response.json()) as ProductResponse | ErrorResponse;
   },
 
   checkIngredientsList: async (
     ingredientsList: string,
     staging?: boolean
   ): Promise<IngredientsCheckResponse> => {
-    try {
-      const API_BASE_URL = getApiBaseUrl(staging);
-      const response = await fetch(
-        `${API_BASE_URL}/ingredients/${ingredientsList}`
-      );
-
-      if (!response.ok) {
-        throw { response: { status: response.status } };
-      }
-
-      return await response.json();
-    } catch (error) {
-      throw error;
+    const API_BASE_URL = getApiBaseUrl(staging);
+    const response = await fetch(
+      `${API_BASE_URL}/ingredients/${ingredientsList}`
+    );
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
     }
+    return (await response.json()) as IngredientsCheckResponse;
   },
 
   getPetaCrueltyFreeBrands: async (
     staging?: boolean
   ): Promise<PetaCrueltyFreeResponse> => {
-    try {
-      const API_BASE_URL = getApiBaseUrl(staging);
-      const response = await fetch(`${API_BASE_URL}/peta/crueltyfree`);
-
-      if (!response.ok) {
-        throw { response: { status: response.status } };
-      }
-
-      return await response.json();
-    } catch (error) {
-      throw error;
+    const API_BASE_URL = getApiBaseUrl(staging);
+    const response = await fetch(`${API_BASE_URL}/peta/crueltyfree`);
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
     }
+    return (await response.json()) as PetaCrueltyFreeResponse;
   },
 };
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -23,7 +23,7 @@ const Veganify = {
       method: "POST",
     });
     if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
+      throw { response: { status: response.status } };
     }
     return (await response.json()) as ProductResponse | ErrorResponse;
   },
@@ -37,7 +37,7 @@ const Veganify = {
       `${API_BASE_URL}/ingredients/${ingredientsList}`
     );
     if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
+      throw { response: { status: response.status } };
     }
     return (await response.json()) as IngredientsCheckResponse;
   },
@@ -48,7 +48,7 @@ const Veganify = {
     const API_BASE_URL = getApiBaseUrl(staging);
     const response = await fetch(`${API_BASE_URL}/peta/crueltyfree`);
     if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
+      throw { response: { status: response.status } };
     }
     return (await response.json()) as PetaCrueltyFreeResponse;
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@frontendnetwork/veganify",
       "version": "1.1.65",
       "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^3.3.2"
+      },
       "devDependencies": {
         "@types/jest": "^29.5.1",
         "@types/node": "^20.1.0",
@@ -2092,6 +2095,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -2541,6 +2553,29 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -2599,6 +2634,18 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -3802,6 +3849,43 @@
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -4737,6 +4821,15 @@
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "@frontendnetwork/veganify",
-  "version": "1.1.65",
+  "version": "1.2.0",
   "description": "A wrapper for the official Veganify API",
   "main": "dist/index.js",
+  "type": "module",
   "scripts": {
     "build": "node build.js",
-    "test": "jest",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "lint": "eslint"
   },
   "repository": {
@@ -39,5 +40,8 @@
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
     "typescript": "^5.0.4"
+  },
+  "dependencies": {
+    "node-fetch": "^3.3.2"
   }
 }

--- a/tests/VeganCheck.test.ts
+++ b/tests/VeganCheck.test.ts
@@ -1,55 +1,80 @@
 import Veganify from "../lib/index.js";
 
 describe("Veganify API Wrapper", () => {
-  test("getProductByBarcode returns product information", async () => {
-    const barcode = "4066600204404";
-    const productInfo = await Veganify.getProductByBarcode(barcode);
-    expect(productInfo).toBeDefined();
-    expect(productInfo).toHaveProperty("product.productname");
+  describe("getProductByBarcode", () => {
+    test("returns product information", async () => {
+      const barcode = "4066600204404";
+      const productInfo = await Veganify.getProductByBarcode(barcode);
+      expect(productInfo).toBeDefined();
+      expect(productInfo).toHaveProperty("product.productname");
+    });
+
+    test("returns 404 on unknown barcode", async () => {
+      const barcode = "01010";
+      await expect(Veganify.getProductByBarcode(barcode)).rejects.toEqual({
+        response: { status: 404 },
+      });
+    }, 15000);
+
+    test("uses staging URL when staging flag is true", async () => {
+      const barcode = "4066600204404";
+      const productInfo = await Veganify.getProductByBarcode(barcode, true);
+      expect(productInfo).toBeDefined();
+      expect(productInfo).toHaveProperty("product.productname");
+    });
   });
 
-  test("getProductByBarcode returns 404 on unknown barcode", async () => {
-    const barcode = "01010";
-    await expect(Veganify.getProductByBarcode(barcode)).rejects.toThrow(Error);
-    await expect(Veganify.getProductByBarcode(barcode)).rejects.toThrow(
-      new Error("HTTP error! status: 404")
-    );
-  }, 15000);
+  describe("checkIngredientsList", () => {
+    test("returns information about ingredients (vegan)", async () => {
+      const ingredientsList = "water, sugar, salt";
+      const ingredientsInfo = await Veganify.checkIngredientsList(
+        ingredientsList
+      );
+      expect(ingredientsInfo).toBeDefined();
+      expect(ingredientsInfo.data.vegan).toBe(true);
+    });
 
-  test.skip("getProductByBarcode returns 400 on bad request", async () => {
-    const barcode = "thisisnotabarcode";
-    await expect(Veganify.getProductByBarcode(barcode)).rejects.toThrow();
+    test("returns information about ingredients (non-vegan)", async () => {
+      const ingredientsList = "water, sugar, salt, duck";
+      const ingredientsInfo = await Veganify.checkIngredientsList(
+        ingredientsList
+      );
+      expect(ingredientsInfo).toBeDefined();
+      expect(ingredientsInfo.data.vegan).toBe(false);
+      expect(ingredientsInfo.data.flagged).toContain("duck");
+    });
+
+    test("returns 400 on bad request", async () => {
+      const ingredientsList = "&/%";
+      await expect(
+        Veganify.checkIngredientsList(ingredientsList)
+      ).rejects.toEqual({
+        response: { status: 400 },
+      });
+    });
+
+    test("uses staging URL when staging flag is true", async () => {
+      const ingredientsList = "water, sugar";
+      const ingredientsInfo = await Veganify.checkIngredientsList(
+        ingredientsList,
+        true
+      );
+      expect(ingredientsInfo).toBeDefined();
+      expect(ingredientsInfo.data.vegan).toBe(true);
+    });
   });
 
-  test("checkIngredientsList returns information about ingredients (vegan)", async () => {
-    const ingredientsList = "water, sugar, salt";
-    const ingredientsInfo = await Veganify.checkIngredientsList(
-      ingredientsList
-    );
-    expect(ingredientsInfo).toBeDefined();
-    expect(ingredientsInfo.data.vegan).toBe(true);
-  });
+  describe("getPetaCrueltyFreeBrands", () => {
+    test("returns a list of cruelty-free brands", async () => {
+      const brands = await Veganify.getPetaCrueltyFreeBrands();
+      expect(brands).toBeDefined();
+      expect(brands.PETA_DOES_NOT_TEST).toContain("_SkinLabo");
+    });
 
-  test("checkIngredientsList returns information about ingredients (non-vegan)", async () => {
-    const ingredientsList = "water, sugar, salt, duck";
-    const ingredientsInfo = await Veganify.checkIngredientsList(
-      ingredientsList
-    );
-    expect(ingredientsInfo).toBeDefined();
-    expect(ingredientsInfo.data.vegan).toBe(false);
-    expect(ingredientsInfo.data.flagged).toContain("duck");
-  });
-
-  test("checkIngredientsList returns 400 on bad request", async () => {
-    const ingredientsList = "&/%";
-    await expect(
-      Veganify.checkIngredientsList(ingredientsList)
-    ).rejects.toThrow();
-  });
-
-  test("getPetaCrueltyFreeBrands returns a list of cruelty-free brands", async () => {
-    const brands = await Veganify.getPetaCrueltyFreeBrands();
-    expect(brands).toBeDefined();
-    expect(brands.PETA_DOES_NOT_TEST).toContain("_SkinLabo");
+    test("uses staging URL when staging flag is true", async () => {
+      const brands = await Veganify.getPetaCrueltyFreeBrands(true);
+      expect(brands).toBeDefined();
+      expect(brands.PETA_DOES_NOT_TEST).toContain("_SkinLabo");
+    });
   });
 });

--- a/tests/VeganCheck.test.ts
+++ b/tests/VeganCheck.test.ts
@@ -1,4 +1,4 @@
-import Veganify from "../lib/index";
+import Veganify from "../lib/index.js";
 
 describe("Veganify API Wrapper", () => {
   test("getProductByBarcode returns product information", async () => {
@@ -9,23 +9,13 @@ describe("Veganify API Wrapper", () => {
   });
 
   test("getProductByBarcode returns 404 on unknown barcode", async () => {
-    const barcode = "0";
-    try {
-      const productInfo = await Veganify.getProductByBarcode(barcode);
-      expect(false).toBeTruthy();
-    } catch (error) {
-      expect(error).toHaveProperty("response.status", 404);
-    }
-  });
+    const barcode = "01010";
+    await expect(Veganify.getProductByBarcode(barcode)).rejects.toThrow();
+  }, 10000);
 
   test.skip("getProductByBarcode returns 400 on bad request", async () => {
     const barcode = "thisisnotabarcode";
-    try {
-      const productInfo = await Veganify.getProductByBarcode(barcode);
-      expect(false).toBeTruthy();
-    } catch (error) {
-      expect(error).toHaveProperty("response.status", 400);
-    }
+    await expect(Veganify.getProductByBarcode(barcode)).rejects.toThrow();
   });
 
   test("checkIngredientsList returns information about ingredients (vegan)", async () => {
@@ -49,14 +39,9 @@ describe("Veganify API Wrapper", () => {
 
   test("checkIngredientsList returns 400 on bad request", async () => {
     const ingredientsList = "&/%";
-    try {
-      const ingredientsInfo = await Veganify.checkIngredientsList(
-        ingredientsList
-      );
-      expect(false).toBeTruthy();
-    } catch (error) {
-      expect(error).toHaveProperty("response.status", 400);
-    }
+    await expect(
+      Veganify.checkIngredientsList(ingredientsList)
+    ).rejects.toThrow();
   });
 
   test("getPetaCrueltyFreeBrands returns a list of cruelty-free brands", async () => {

--- a/tests/VeganCheck.test.ts
+++ b/tests/VeganCheck.test.ts
@@ -10,8 +10,11 @@ describe("Veganify API Wrapper", () => {
 
   test("getProductByBarcode returns 404 on unknown barcode", async () => {
     const barcode = "01010";
-    await expect(Veganify.getProductByBarcode(barcode)).rejects.toThrow();
-  }, 10000);
+    await expect(Veganify.getProductByBarcode(barcode)).rejects.toThrow(Error);
+    await expect(Veganify.getProductByBarcode(barcode)).rejects.toThrow(
+      new Error("HTTP error! status: 404")
+    );
+  }, 15000);
 
   test.skip("getProductByBarcode returns 400 on bad request", async () => {
     const barcode = "thisisnotabarcode";


### PR DESCRIPTION
## Summary by Sourcery

Use `node-fetch` for HTTP requests to improve compatibility, refactor API methods for cleaner code, update build script to ES module syntax, and adjust Jest configuration for ES module support.

New Features:
- Introduce the use of `node-fetch` for making HTTP requests to enhance compatibility across different environments.

Enhancements:
- Refactor the API request methods to remove try-catch blocks, simplifying the code structure.
- Update the build script to use ES module syntax and improve file copying logic for non-TypeScript files.

Build:
- Modify the build script to use ES module imports and handle file operations with Node.js built-in modules.

Tests:
- Update Jest configuration to support ES modules by using `ts-jest/presets/default-esm` and configuring module name mapping and transformation.