### PR TITLE
fix: Add back types

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,6 +1,6 @@
 import { execSync } from 'child_process';
 import { fileURLToPath } from 'url';
-import { dirname } from 'path';
+import { dirname, join } from 'path';
 import fs from 'fs';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -20,7 +20,7 @@ try {
 
     fs.readdirSync(sourceDir).forEach(file => {
         if (!file.endsWith('.ts')) {
-            fs.copyFileSync(`${sourceDir}/${file}`, `${targetDir}/${file}`);
+            fs.copyFileSync(join(sourceDir, file), join(targetDir, file));
         }
     });
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -27,7 +27,6 @@ const Veganify = {
     }
     return (await response.json()) as ProductResponse | ErrorResponse;
   },
-
   checkIngredientsList: async (
     ingredientsList: string,
     staging?: boolean
@@ -41,7 +40,6 @@ const Veganify = {
     }
     return (await response.json()) as IngredientsCheckResponse;
   },
-
   getPetaCrueltyFreeBrands: async (
     staging?: boolean
   ): Promise<PetaCrueltyFreeResponse> => {
@@ -55,3 +53,9 @@ const Veganify = {
 };
 
 export default Veganify;
+export {
+  ProductResponse,
+  IngredientsCheckResponse,
+  PetaCrueltyFreeResponse,
+  ErrorResponse,
+};

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.2.1",
   "description": "A wrapper for the official Veganify API",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "type": "module",
   "scripts": {
     "build": "node build.js",

--- a/tests/VeganCheck.test.ts
+++ b/tests/VeganCheck.test.ts
@@ -10,7 +10,7 @@ describe("Veganify API Wrapper", () => {
     });
 
     test("returns 404 on unknown barcode", async () => {
-      const barcode = "01010";
+      const barcode = "0101010101010";
       await expect(Veganify.getProductByBarcode(barcode)).rejects.toEqual({
         response: { status: 404 },
       });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,18 @@
 {
-    "compilerOptions": {
-      /* Basic Options */
-      "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
-      "lib": ["es2015", "dom"],                 /* List of library files to be included in the compilation. */
-      "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-      "allowJs": true,                          /* Allow javascript files to be compiled. */
-      "sourceMap": true,                        /* Generates corresponding '.map' file. */
-      "outDir": "./dist",                       /* Redirect output structure to the directory. */
-      /* Strict Type-Checking Options */
-      "strict": true,                           /* Enable all strict type-checking options. */
-      "noImplicitAny": false,                   /* Raise error on expressions and declarations with an implied 'any' type. */
-      /* Module Resolution Options */
-      "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-    },
-    "include": [
-      "lib/**/*"
-    ]
-  }
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["es2020", "dom"],
+    "moduleResolution": "node",
+    "outDir": "./dist",
+    "rootDir": "./lib",
+    "strict": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "declaration": true,
+    "sourceMap": true,
+    "noImplicitAny": true
+  },
+  "include": ["lib/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary by Sourcery

Update TypeScript configuration to modern standards, export additional types from the main module, and improve file path handling in the build script. Fix a test case to correctly simulate a 404 error.

Bug Fixes:
- Correct the barcode used in the test for unknown barcode to ensure it triggers a 404 response.

Enhancements:
- Update TypeScript configuration to target ES2020, use ESNext modules, and enable declaration file generation.
- Refactor file path handling in the build script to use path.join for better cross-platform compatibility.